### PR TITLE
Update pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ build/tmp*/
 build/build.log
 bin/zssServer
 
+# workspace content should be updated by program
+.pax/*
+!.pax/.keep
+!.pax/pre-packaging.sh
+!.pax/post-packaging.sh
+!.pax/prepare-workspace.sh
+
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -1,0 +1,39 @@
+#!/bin/sh -e
+set -x
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright IBM Corporation 2018, 2019
+################################################################################
+
+# contants
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR=$(dirname "$0")
+# these are folders on build server
+export JAVA_HOME=/usr/lpp/java/J8.0_64
+export ANT_HOME=/ZOWE/apache-ant-1.10.5
+export STEPLIB=CBC.SCCNCMP
+
+# build
+echo "$SCRIPT_NAME build zss ..."
+cd build && ${ANT_HOME}/bin/ant
+
+# clean up content folder
+echo "$SCRIPT_NAME cleaning up pax folder ..."
+cd "$SCRIPT_DIR"
+mv content bak && mkdir -p content
+
+# move real files to the content folder
+echo "$SCRIPT_NAME coping files should be in pax ..."
+cd content
+mkdir LOADLIB SAMPLIB &&
+  cp -X "//DEV.LOADLIB(ZWESIS01)" LOADLIB/ZWESIS01  &&
+  cp -X "//DEV.LOADLIB(ZWESAUX)" LOADLIB/ZWESAUX  &&
+  cp ../bak/samplib/zis/* SAMPLIB/  &&
+  cp ../bak/bin/zssServer ./  &&
+  extattr +p zssServer

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -13,7 +13,7 @@ set -x
 
 # contants
 SCRIPT_NAME=$(basename "$0")
-SCRIPT_DIR=$(dirname "$0")
+SCRIPT_DIR=$(pwd)
 # these are folders on build server
 export JAVA_HOME=/usr/lpp/java/J8.0_64
 export ANT_HOME=/ZOWE/apache-ant-1.10.5
@@ -30,7 +30,7 @@ mv content bak && mkdir -p content
 
 # move real files to the content folder
 echo "$SCRIPT_NAME coping files should be in pax ..."
-cd content
+cd "$SCRIPT_DIR/content"
 mkdir LOADLIB SAMPLIB &&
   cp -X "//DEV.LOADLIB(ZWESIS01)" LOADLIB/ZWESIS01  &&
   cp -X "//DEV.LOADLIB(ZWESAUX)" LOADLIB/ZWESAUX  &&

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -21,7 +21,7 @@ export STEPLIB=CBC.SCCNCMP
 
 # build
 echo "$SCRIPT_NAME build zss ..."
-cd build && ${ANT_HOME}/bin/ant
+cd "$SCRIPT_DIR/content/build" && ${ANT_HOME}/bin/ant
 
 # clean up content folder
 echo "$SCRIPT_NAME cleaning up pax folder ..."

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+set -x
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright IBM Corporation 2019
+################################################################################
+
+################################################################################
+# Prepare folders/files will be uploaded to Build/PAX server
+################################################################################
+
+# contants
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR=$(dirname "$0")
+PAX_WORKSPACE_DIR=.pax
+
+# make sure in project root folder
+cd $SCRIPT_DIR/..
+
+# prepare pax workspace
+echo "[${SCRIPT_NAME}] preparing folders ..."
+rm -fr "${PAX_WORKSPACE_DIR}/ascii" && mkdir -p "${PAX_WORKSPACE_DIR}/ascii"
+rm -fr "${PAX_WORKSPACE_DIR}/content" && mkdir -p "${PAX_WORKSPACE_DIR}/content"
+
+echo "[${SCRIPT_NAME}] copying files ..."
+cp -R * "${PAX_WORKSPACE_DIR}/ascii"
+# move files shouldn't change encoding to IBM-1047 to content folder
+rsync -rv \
+  --include '*/' \
+  --include '*.png' \
+  --exclude '*' \
+  --prune-empty-dirs --remove-source-files \
+  "${PAX_WORKSPACE_DIR}/ascii/" \
+  "${PAX_WORKSPACE_DIR}/content/"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,20 +19,6 @@ node("ibm-jenkins-slave-nvm") {
 
     pipeline.setup(
         packageName: 'org.zowe.zss',
-        github: [
-            email                      : lib.Constants.DEFAULT_GITHUB_ROBOT_EMAIL,
-            usernamePasswordCredential : lib.Constants.DEFAULT_GITHUB_ROBOT_CREDENTIAL,
-        ],
-        artifactory: [
-            url                        : lib.Constants.DEFAULT_ARTIFACTORY_URL,
-            usernamePasswordCredential : lib.Constants.DEFAULT_ARTIFACTORY_ROBOT_CREDENTIAL,
-        ],
-        pax: [
-            sshHost                    : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_HOST,
-            sshPort                    : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_PORT,
-            sshCredential              : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_CREDENTIAL,
-            remoteWorkspace            : lib.Constants.DEFAULT_PAX_PACKAGING_REMOTE_WORKSPACE,
-        ],
         extraInit: {
             def version = [
                 sh(script: "cat build/version.properties | grep PRODUCT_MAJOR_VERSION | awk -F= '{print \$2};'", returnStdout: true).trim(),
@@ -50,19 +36,12 @@ node("ibm-jenkins-slave-nvm") {
         }
     )
 
-    pipeline.test(
-        name              : "Smoke",
-        operation         : {
-            echo "Test will happen in pre-packaging"
-        },
-        allowMissingJunit : true
-    )
-
     // define we need packaging stage, which processed in .pax folder
     pipeline.packaging(name: 'zss', paxOptions: '-x os390')
 
     // define we need publish stage
     pipeline.publish(
+        allowPublishWithoutTest: true,
         artifacts: [
             '.pax/zss.pax',
         ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 node("ibm-jenkins-slave-nvm") {
 
-    def lib = library("jenkins-library").org.zowe.jenkins_shared_library
+    def lib = library("jenkins-library@users/jack/default-values").org.zowe.jenkins_shared_library
     def pipeline = lib.pipelines.generic.GenericPipeline.new(this)
 
     pipeline.admins.add("dnikolaev", "sgrady")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,84 +10,54 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-
-BUILD_SERVER_TMP_DIR = "/ZOWE/tmp"
-JAVA_HOME = "/usr/lpp/java/J8.0_64"
-ANT_HOME = "/ZOWE/apache-ant-1.10.5"
-XLC_DATASET = "CBC.SCCNCMP"
-
-
 node("ibm-jenkins-slave-nvm") {
 
     def lib = library("jenkins-library").org.zowe.jenkins_shared_library
     def pipeline = lib.pipelines.generic.GenericPipeline.new(this)
 
-    def buildDir = "${BUILD_SERVER_TMP_DIR}/~${env.BUILD_TAG}"
-    def buildServer = null
-
-    withCredentials([usernamePassword(
-        credentialsId: lib.Constants.DEFAULT_PAX_PACKAGING_SSH_CREDENTIAL,
-        usernameVariable: "BUILD_SERVER_USERNAME",
-        passwordVariable: "BUILD_SERVER_PASSWORD"
-    )]) {
-        buildServer = [
-            name         : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_HOST,
-            host         : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_HOST,
-            port         : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_PORT.toInteger(),
-            user         : BUILD_SERVER_USERNAME,
-            password     : BUILD_SERVER_PASSWORD,
-            allowAnyHosts: true
-        ]
-    }
-
     pipeline.admins.add("dnikolaev", "sgrady")
 
-    pipeline.setup()
-
-    pipeline.createStage(
-        name: 'Deploy source',
-        stage: {
-            sh "tar --exclude='./source.tar' -cf source.tar *"
-            sshCommand remote: buildServer, command: "rm -rf ${buildDir} && mkdir -p \$_"
-            sshPut remote: buildServer, from: "source.tar", into: buildDir
-            sshCommand remote: buildServer, command: \
-                """
-                cd ${buildDir} &&
-                pax -r -x tar -o to=IBM-1047 -f source.tar
-                """
+    pipeline.setup(
+        packageName: 'org.zowe.zss',
+        github: [
+            email                      : lib.Constants.DEFAULT_GITHUB_ROBOT_EMAIL,
+            usernamePasswordCredential : lib.Constants.DEFAULT_GITHUB_ROBOT_CREDENTIAL,
+        ],
+        artifactory: [
+            url                        : lib.Constants.DEFAULT_ARTIFACTORY_URL,
+            usernamePasswordCredential : lib.Constants.DEFAULT_ARTIFACTORY_ROBOT_CREDENTIAL,
+        ],
+        pax: [
+            sshHost                    : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_HOST,
+            sshPort                    : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_PORT,
+            sshCredential              : lib.Constants.DEFAULT_PAX_PACKAGING_SSH_CREDENTIAL,
+            remoteWorkspace            : lib.Constants.DEFAULT_PAX_PACKAGING_REMOTE_WORKSPACE,
+        ],
+        extraInit: {
+            def version = [
+                sh(script: "cat build/version.properties | grep PRODUCT_MAJOR_VERSION | awk -F= '{print \$2};'", returnStdout: true).trim(),
+                sh(script: "cat build/version.properties | grep PRODUCT_MINOR_VERSION | awk -F= '{print \$2};'", returnStdout: true).trim(),
+                sh(script: "cat build/version.properties | grep PRODUCT_REVISION | awk -F= '{print \$2};'", returnStdout: true).trim(),
+            ].join('.')
+            pipeline.setVersion(version)
+            echo "Current version is v${version}"
         }
     )
 
     pipeline.build(
         operation: {
-            sshCommand remote: buildServer, command: \
-                """
-                export JAVA_HOME=${JAVA_HOME} &&
-                export ANT_HOME=${ANT_HOME} &&
-                export STEPLIB=${XLC_DATASET} &&
-                cd ${buildDir}/build &&
-                ${ANT_HOME}/bin/ant
-                """
+            echo "Build will happen in pre-packaging"
         }
     )
 
-    pipeline.packaging(
-        name: 'zss',
-        operation: {
-            sshCommand remote: buildServer, command: \
-                """
-                cd ${buildDir} &&
-                mkdir LOADLIB SAMPLIB &&
-                cp -X "//DEV.LOADLIB(ZWESIS01)" LOADLIB/ZWESIS01  &&
-                cp -X "//DEV.LOADLIB(ZWESAUX)" LOADLIB/ZWESAUX  &&
-                cp samplib/zis/* SAMPLIB/  &&
-                cp bin/zssServer ./  &&
-                extattr +p zssServer &&
-                pax -x os390 -w -f zss.pax SAMPLIB LOADLIB zssServer
-                """
-            sshGet remote: buildServer, from: "${buildDir}/zss.pax", into: "zss.pax"
-            sshCommand remote: buildServer, command:  "rm -rf ${buildDir}"
-        }
+    // define we need packaging stage, which processed in .pax folder
+    pipeline.packaging(name: 'zss')
+
+    // define we need publish stage
+    pipeline.publish(
+        artifacts: [
+            '.pax/zss.pax',
+        ]
     )
 
     pipeline.end()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,16 @@ node("ibm-jenkins-slave-nvm") {
         }
     )
 
+    pipeline.test(
+        name              : "Smoke",
+        operation         : {
+            echo "Test will happen in pre-packaging"
+        },
+        allowMissingJunit : true
+    )
+
     // define we need packaging stage, which processed in .pax folder
-    pipeline.packaging(name: 'zss')
+    pipeline.packaging(name: 'zss', paxOptions: '-x os390')
 
     // define we need publish stage
     pipeline.publish(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 
 node("ibm-jenkins-slave-nvm") {
 
-    def lib = library("jenkins-library@users/jack/default-values").org.zowe.jenkins_shared_library
+    def lib = library("jenkins-library").org.zowe.jenkins_shared_library
     def pipeline = lib.pipelines.generic.GenericPipeline.new(this)
 
     pipeline.admins.add("dnikolaev", "sgrady")


### PR DESCRIPTION
- changed to use .pax to control packaging process.
- add publish stage to push zss.pax to Artifactory.

Please note one difference, in `.pax/pre-packaging.sh`, `zis-aux/img/aux-diagram.png` is excluded from ascii folder which means it will remain as-is, won't be converted to IBM-1047. In the old pipeline, the png will be also converted to IBM-1047 encoding. Please evaluate if this is ok.

Example build console log: https://wash.zowe.org:8443/job/zss/job/PR-99/4/console
Example build result: libs-snapshot-local/org/zowe/zss/1.6.0-PR-99/zss-1.6.0-pr-99-4-20191101173040.pax